### PR TITLE
DAQmxBase on linux support

### DIFF
--- a/PyDAQmx/DAQmxConfig.py
+++ b/PyDAQmx/DAQmxConfig.py
@@ -21,14 +21,36 @@ if sys.platform.startswith('win'):
     # Default on Windows is nicaiu
     lib_name = "nicaiu"
 
+    # This is DAQmx based.
+    lib_type = 'DAQmx'
+
+    # No extra libs need to be loaded explicitly.
+    extra_lib_names = None
+
 elif sys.platform.startswith('linux'):
     # On linux you can use the command find_library('nidaqmx')
 
-    # Full path of the NIDAQmx.h file
-    dot_h_file = '/usr/local/natinst/nidaqmx/include/NIDAQmx.h'
+    # We could be using either DAQmx or DAQmxBase. Each has a different
+    # header and library file. In addition, DAQmxBase requires an extra
+    # library to be loaded explicitly first in order to work.
 
-    # Name (and eventually path) of the library
-    lib_name = 'libnidaqmx.so'
+    nidaq_libs = {'DAQmx': {'dot_h_file': '/usr/local/natinst/nidaqmx/include/NIDAQmx.h',
+                  'lib_name': '/usr/local/natinst/nidaqmx/lib/libnidaqmx.so',
+                  'extra_lib_names': None},
+                  'DAQmxBase': {'dot_h_file': '/usr/local/natinst/nidaqmxbase/include/NIDAQmx.h',
+                  'lib_name': '/usr/local/natinst/nidaqmxbase/lib/libnidaqmxbase.so',
+                  'extra_lib_names': ('/usr/local/lib/liblvrtdark.so',)}}
+
+    if os.path.exists(nidaq_libs['DAQmx']['dot_h_file']):
+        lib_type = 'DAQmx'
+    elif os.path.exists(nidaq_libs['DAQmxBase']['dot_h_file']):
+        lib_type = 'DAQmxBase'
+    else:
+        raise NotImplementedError, "Location of niDAQmx or niDAQmxBase library and include file unknown on %s - if you find out, please let the PyDAQmx project know" % (sys.platform)
+
+    dot_h_file = nidaq_libs[lib_type]['dot_h_file']
+    lib_name = nidaq_libs[lib_type]['lib_name']
+    extra_lib_names = nidaq_libs[lib_type]['extra_lib_names']
 
 if dot_h_file is None:
     raise NotImplementedError, "Location of niDAQmx library and include file unknown on %s - if you find out, please let the PyDAQmx project know" % (sys.platform)

--- a/PyDAQmx/DAQmxConfig.py
+++ b/PyDAQmx/DAQmxConfig.py
@@ -37,8 +37,8 @@ elif sys.platform.startswith('linux'):
     nidaq_libs = {'DAQmx': {'dot_h_file': '/usr/local/natinst/nidaqmx/include/NIDAQmx.h',
                   'lib_name': '/usr/local/natinst/nidaqmx/lib/libnidaqmx.so',
                   'extra_lib_names': None},
-                  'DAQmxBase': {'dot_h_file': '/usr/local/natinst/nidaqmxbase/include/NIDAQmx.h',
-                  'lib_name': '/usr/local/natinst/nidaqmxbase/lib/libnidaqmxbase.so',
+                  'DAQmxBase': {'dot_h_file': '/usr/local/natinst/nidaqmxbase/include/NIDAQmxBase.h',
+                  'lib_name': '/usr/local/lib/libnidaqmxbase.so',
                   'extra_lib_names': ('/usr/local/lib/liblvrtdark.so',)}}
 
     if os.path.exists(nidaq_libs['DAQmx']['dot_h_file']):

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,8 +3,8 @@ Welcome to PyDAQmx's documentation!
 ===================================
 
 This package allows users to use data acquisition hardware from `National
-Instruments`_ with Python. It provides an interface between the NIDAQmx driver
-and Python. The package works on Windows and Linux.
+Instruments`_ with Python. It provides an interface between the
+NIDAQmx/NIDAQmxBase driver and Python. The package works on Windows and Linux.
 
 .. note::
 
@@ -12,9 +12,10 @@ and Python. The package works on Windows and Linux.
     first need to install the driver provided by NI.
 
 Compared to similar packages, the PyDAQmx module is a full interface to the
-NIDAQmx ANSI C driver. It imports all the functions from the driver and imports
-all the predefined constants. This provides an almost one-to-one match between
-C and Python code.
+NIDAQmx/NIDAQmxBase ANSI C driver. It imports all the functions from the
+driver and imports all the predefined constants. This provides an almost
+one-to-one match between C and Python code except that 'Base' is removed
+from function names if the NIDAQmxBase driver is being used.
 
 A more convenient object-oriented interface is also provided, where the
 mechanisms of :data:`taskHandle` in C is replaced with a :ref:`Task-object`.
@@ -24,7 +25,7 @@ The module supports callback functions, see :doc:`callback`
 Installation
 ============
 
-You first need to install the NI DAQmx driver provided with your
+You first need to install the NI DAQmx or DAQmxBase driver provided with your
 data-acquisition hardware. Please verify that you have installed together with
 the driver the C API (which should be the case by default).
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -2,7 +2,7 @@
 Installation
 ============
 
-First you need to install the NI DAQmx driver provided with your
+First you need to install the NI DAQmx or DAQmxBase driver provided with your
 data-acquisition hardware. Please verify that you have installed together with
 the driver the C API (which should be the case by default). The C API reference
 help file is also recommended.
@@ -12,9 +12,10 @@ After installing the driver, you need to find the location of the file
 :file:`%ProgramFiles%/National Instruments/NI-DAQ/DAQmx ANSI C/NIDAQmx.h`
 (where :envvar:`%ProgramFiles%` is typically :file:`C:/Program Files/`), and on
 linux it is assumed to be located at
-:file:`/usr/local/natinst/nidaqmx/include/NIDAQmx.h`. If this not the case on
-your system, modify the :file:`DAQmxConfig.py` file in the :mod:`PyDAQmx`
-module.
+:file:`/usr/local/natinst/nidaqmx/include/NIDAQmx.h` or
+:file:`/usr/local/natinst/nidaqmxbase/include/NIDAQmx.h`. If this not the
+case on your system, modify the :file:`DAQmxConfig.py` file in the
+:mod:`PyDAQmx` module.
 
 The package also works under linux (but be aware that only a few linux
 distributions are supported by National Instruments).

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -6,8 +6,9 @@ How to use PyDAQmx
 ==================
 
 The :mod:`PyDAQmx` module uses :mod:`ctypes` to interface with the NI-DAQmx
-dll. We thus advise users of :mod:`PyDAQmx` to read and understand the
-documentation of :mod:`ctypes`.
+dll on Windows or the NI-DAQmx or NI-DAQmxBase so on Linux. We thus advise
+users of :mod:`PyDAQmx` to read and understand the documentation of
+:mod:`ctypes`.
 
 Three core modules are defined, and one higher-level object-oriented module:
 
@@ -22,6 +23,16 @@ Three core modules are defined, and one higher-level object-oriented module:
   :func:`DAQmxCfgSampClkTiming()`, etc.).
 * :mod:`PyDAQmx.Task` provides an object-oriented interface to NIDAQmx
   :data:`taskHandle` objects. See the section :ref:`Task-object`.
+
+
+NI-DAQmxBase
+------------
+
+The NI-DAQmxBase drivers are a stripped down version of the NI-DAQmx drivers
+having less functions and the functions renamed from starting with
+'DAQmx' to 'DAQmxBase' (note, this package removes the 'Base' part so the
+calling conventions will be the same). If both NI-DAQmx and NI-DAQmxBase
+are available, NI-DAQmx will be used.
 
 
 Argument types


### PR DESCRIPTION
These changes add support for the DAQmxBase library on Linux. As NI is no longer doing new DAQmx releases on Linux, just DAQmxBase (as far as I can tell), this library has to be supported to work with newer DAQs. Note, I have only tested this on Python 3.3, so I don't know how well it will work on Python 2. There is one line in particular that I worry might have issues, which I will mention below.

The first and third commits (128d426 and f4ea7e3) are changes to the code itself, while the second commit (13b8293) is an update to the documentation to reflect the changes.

Besides the DAQmxBase library and its header being found in different locations and having different names, it also requires another library (liblvrtdark.so) to be loaded first manually and the functions in the library need to have the 'Base' stripped out of the leading 'DAQmxBase' part so that the functions will have the same names as in DAQmx to maintain compatibility. Then, the only difference is that there are just less of the functions available. Those missing functions are still found by the code that parses the header file, but then are not in the library, so I made it so that missing functions in the library are skipped.

It is the line

    extra_libs = [CDLL(lb, mode=ctypes.RTLD_GLOBAL) for lb in extra_lib_names]

on the new line 54 of PyDAQmx/DAQmxFunctions.py that I worry may not be compatible with Python 2. 

I also added a new variable lib_type which is set to either 'DAQmx' or 'DAQmxBase' in PyDAQmx/DAQmxConfig.py so that a user can tell which library is being used.