### PR TITLE
distribute license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE.txt
+include README.md
+


### PR DESCRIPTION
Currently PyDAQmx does not distribute it's license on PyPI [1]. By adding a MANIFEST file you can instruct your packaging tool to make sure the license is included [2].

I've taken the liberty of also including your readme, although I think this is less important.

[1] https://pypi.org/project/PyDAQmx/#files
[2] https://packaging.python.org/guides/using-manifest-in/