### PR TITLE
advertise new conda-forge installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,26 @@ Windows 7. It works with Python 2 (from 2.7) and Python 3.
 
 ## Installation
 
-To install this package:
+### source
+
+To install this package from [source](https://github.com/clade/PyDAQmx):
 
 1. Install the NI-DAQmx driver. 
 2. Run `python setup.py install`.
 
+### PyPI
+
+To install this package from [PyPI](https://pypi.org/project/PyDAQmx/):
+
+1. Install the NI-DAQmx driver.
+2. Run `python -m pip install PyDAQmx`
+
+### conda-forge
+
+To install this package from [conda-forge](https://anaconda.org/conda-forge/pydaqmx):
+
+1. Install the NI-DAQmx driver
+2. Run `conda install -c conda-forge pydaqmx`
 
 ## License
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -41,6 +41,12 @@ or using `pip <http://www.pip-installer.org/>`_:
 
     pip install PyDAQmx
 
+or using `conda-forge <https://anaconda.org/conda-forge/pydaqmx/>`_:
+
+.. code-block:: sh
+
+    conda install -c conda-forge pydaqmx
+
 You can also directly *move* the :file:`PyDAQmx` directory to a location that
 Python can import from (the directory in which scripts using :mod:`PyDAQmx` are
 run, :data:`sys.path`, etc.)

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -25,6 +25,12 @@ or using `pip <http://www.pip-installer.org/>`_:
 
     pip install PyDAQmx
 
+or using `conda-forge <https://anaconda.org/conda-forge/pydaqmx/>`_:
+
+.. code-block:: sh
+
+    conda install -c conda-forge pydaqmx
+
 You can also directly *move* the :file:`PyDAQmx` directory to a location that
 Python can import from (the directory in which scripts using :mod:`PyDAQmx` are
 run, :data:`sys.path`, etc.)


### PR DESCRIPTION
PyDAQmx is newly available through conda on conda-forge. This PR updates the docs so that people are aware of this option.

conda-forge works by having a "feedstock" repository for each package. A bot comes around and builds the package from this repository. It's not a lot of work to maintain---here's the feedstock for PyDAQmx

https://github.com/conda-forge/pydaqmx-feedstock

Currently the only maintainers of this feedstock are myself and my colleague @ksunden, neither of us are PyDAQmx developers. I'd be happy to add others or relinquish my maintainership of this feedstock to anyone else just let me know. 